### PR TITLE
docs: add installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Options:
 cargo run -- key | cargo run -- generate --assertion p14n --expires-in 5s
 ```
 
+## Installation
+
+```shell
+cargo install --git "https://github.com/bettermarks/paseto-cli"
+```
+
 ## TODO
 
 - validation


### PR DESCRIPTION
Since it might not be so obvious that it's not on crates.io / may help the less experienced Rustaceans 