### PR TITLE
ci: add lint workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  codestyle:
+    name: Codestyle
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check
+        env:
+          RUSTFLAGS: '-D unused'
+      - run: cargo clippy -- -D clippy::all
+      - run: cargo fmt --check

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Ok, Result};
 use base64::prelude::*;
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use humantime::Duration;
 use pasetors::{
     claims::Claims,
@@ -9,7 +9,6 @@ use pasetors::{
     version4::V4,
 };
 use std::io::{self, Read};
-use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
It feels a bit naughty to have warnings show on the install, so I was thinking to add a lint check to prevent them for the case of future changes
```
RUSTFLAGS="-D unused" cargo check
```

```
warning: unused import: `ArgAction`
 --> src/main.rs:3:12
  |
3 | use clap::{ArgAction, Parser, Subcommand};
  |            ^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::str::FromStr`
  --> src/main.rs:12:5
   |
12 | use std::str::FromStr;
   |     ^^^^^^^^^^^^^^^^^

warning: `paseto-cli` (bin "paseto-cli") generated 2 warnings (run `cargo fix --bin "paseto-cli"` to apply 2 suggestions)
```

I found the way to do it in https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html 

It does state that new warnings might pop up with new rust versions and deps, including deprecations so I figured `RUSTFLAGS="-D all" cargo check` might cause too much friction.
Maybe there are more to added... but I guess clippy has our back for most issues.

I feel it's nicer not to add it to the code because it gets in the way of iteration